### PR TITLE
Use time-domain stretching in KWS20 data loader; add higher performance KWS20 v3 network

### DIFF
--- a/models/ai85net-kws20-v3.py
+++ b/models/ai85net-kws20-v3.py
@@ -56,7 +56,7 @@ class AI85KWS20Netv3(nn.Module):
         self.kws_conv4 = ai8x.FusedMaxPoolConv1dReLU(100, 64, 6, stride=1, padding=1,
                                                      bias=bias, **kwargs)
         # T : 2 F: 128
-        self.fc = ai8x.Linear(256, num_classes, bias=bias)
+        self.fc = ai8x.Linear(256, num_classes, bias=bias, wide=True, **kwargs)
 
     def forward(self, x):  # pylint: disable=arguments-differ
         """Forward prop"""

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,4 +14,5 @@ torchvision==0.8.1
 tensorboard==2.4.0
 numba<0.50.0
 opencv-python>=4.4.0
+pytsmod>=0.3.3
 -e distiller

--- a/scripts/evaluate_kws20_v3.sh
+++ b/scripts/evaluate_kws20_v3.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+./train.py --model ai85kws20netv3 --dataset KWS_20 --confusion --evaluate --exp-load-weights-from ../ai8x-synthesis/trained/ai85-kws20_v3-qat8-q.pth.tar -8 --device MAX78000 "$@"

--- a/scripts/train_kws20_v3.sh
+++ b/scripts/train_kws20_v3.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+./train.py --epochs 200 --optimizer Adam --lr 0.001 --deterministic --compress schedule_kws20.yaml --model ai85kws20netv3 --dataset KWS_20 --confusion --device MAX78000 "$@"

--- a/train_all_models.sh
+++ b/train_all_models.sh
@@ -30,6 +30,9 @@ echo "-----------------------------"
 echo "Training kws20_v2 model"
 scripts/train_kws20_v2.sh
 echo "-----------------------------"
+echo "Training kws20_v3 model"
+scripts/train_kws20_v3.sh
+echo "-----------------------------"
 echo "Training faceid model"
 scripts/train_faceid.sh
 


### PR DESCRIPTION
PyTSMod is for time-scale stretching to be used for augmentation of the KWS dataset. I am recommending to replace the librosa.effects-based function, which brings an undesired echo effect, due to phase mismatch in the Fourier domain.