### PR TITLE
Make --save-sample compatible with other validation options

### DIFF
--- a/train.py
+++ b/train.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 ###################################################################################################
 #
-# Copyright (C) 2019-2021 Maxim Integrated Products, Inc. All Rights Reserved.
+# Copyright (C) 2019-2022 Maxim Integrated Products, Inc. All Rights Reserved.
 #
 # Maxim Integrated Products, Inc. Default Copyright Notice:
 # https://www.maximintegrated.com/en/aboutus/legal/copyrights.html
@@ -995,7 +995,7 @@ def _validate(data_loader, model, criterion, loggers, args, epoch=-1, tflogger=N
                             and model.__dict__['_modules'][key].wide):
                         output /= 256.
 
-            if args.generate_sample is not None and sample_saved is False:
+            if args.generate_sample is not None and not sample_saved:
                 sample.generate(args.generate_sample, inputs, target, output, args.dataset, False)
                 sample_saved = True
 

--- a/train.py
+++ b/train.py
@@ -981,6 +981,7 @@ def _validate(data_loader, model, criterion, loggers, args, epoch=-1, tflogger=N
     end = time.time()
     class_probs = []
     class_preds = []
+    sample_saved = False  # Track if --save-sample has been done for this validation step
     for validation_step, (inputs, target) in enumerate(data_loader):
         with torch.no_grad():
             inputs, target = inputs.to(args.device), target.to(args.device)
@@ -994,9 +995,9 @@ def _validate(data_loader, model, criterion, loggers, args, epoch=-1, tflogger=N
                             and model.__dict__['_modules'][key].wide):
                         output /= 256.
 
-            if args.generate_sample is not None:
+            if args.generate_sample is not None and sample_saved is False:
                 sample.generate(args.generate_sample, inputs, target, output, args.dataset, False)
-                return .0, .0, .0
+                sample_saved = True
 
             if args.csv_prefix is not None:
                 save_tensor(inputs, f_x)


### PR DESCRIPTION
As reported by issue #135 the --save-sample command-line option disabled almost all of the other validation steps in the log file output.

The culprit was [this](https://github.com/MaximIntegratedAI/ai8x-training/blob/a7068a5907f06fa99bd6106744a80218342abe3e/train.py#L999) return statement.  This PR replaces the return statement with a boolean check to allow the _validate function to continue even if --sample-sample is specified.

Ex:  From `scripts/train_mnist.py` with `--save-sample 10`

```shell
--- validate (epoch=136)-----------
6000 samples (256 per mini-batch)
==> Saving sample at index 10 to sample_mnist.npy  <-- *Sample 10 is saved correctly, confusion matrix etc. are still printed*
Epoch: [136][   10/   24]    Loss 0.037971    Top1 99.179688    Top5 100.000000
Epoch: [136][   20/   24]    Loss 0.040987    Top1 99.062500    Top5 100.000000
Epoch: [136][   24/   24]    Loss 0.042631    Top1 98.983333    Top5 100.000000
==> Top1: 98.983    Top5: 100.000    Loss: 0.043

==> Confusion:
[[601   0   1   0   0   0   2   0   0   1]
 [  0 684   1   0   0   0   0   3   0   0]
 [  0   1 581   1   0   0   0   3   0   0]
 [  0   0   0 578   0   2   0   2   1   0]
 [  0   0   1   0 555   1   0   0   0   8]
 [  0   0   0   1   0 514   2   0   1   0]
 [  0   0   0   0   3   2 625   0   1   0]
 [  0   2   0   0   0   0   0 623   0   0]
 [  0   0   0   1   0   1   4   0 576   2]
 [  1   1   0   1   1   3   0   4   2 602]]

==> Best [Top1: 99.167   Top5: 100.000   Sparsity:0.00   Params: 71148 on epoch: 128]
Saving checkpoint to: logs/2022.03.22-145942/qat_checkpoint.pth.tar
```