### PR TITLE
Add Feature: dummy checkpoint

### DIFF
--- a/parsecmd.py
+++ b/parsecmd.py
@@ -74,6 +74,7 @@ def get_parser(model_names, dataset_names):
     parser.add_argument('--avg-pool-rounding', action='store_true', default=False,
                         help='when simulating, use "round()" in AvgPool operations '
                              '(default: use "floor()")')
+    parser.add_argument('--dummy_checkpoint', dest='dummy_checkpoint', action='store_true', default=False, help='Not train but save a dummy checkpoint file')
 
     qat_args = parser.add_argument_group('Quantization Arguments')
     qat_args.add_argument('--qat-policy', dest='qat_policy',

--- a/train.py
+++ b/train.py
@@ -423,6 +423,13 @@ def main():
     elif compression_scheduler is None:
         compression_scheduler = distiller.CompressionScheduler(model)
 
+    if args.dummy_checkpoint:
+        apputils.save_checkpoint(0, args.cnn, model, optimizer=None,
+                                    scheduler=compression_scheduler,
+                                    is_best=False, name="dummy",
+                                    dir=msglogger.logdir)
+        return None
+
     # Model is re-transferred to GPU in case parameters were added (e.g. PACTQuantizer)
     model.to(args.device)
 


### PR DESCRIPTION
Creating an option to create a dummy checkpoint for a model code.
It creates an untrained checkpoint file starting the training.
This helps to measure the model performance (latency) on the boards before finalizing the model architecture for actual training.