### PR TITLE
torch.Tensor changed to torch.tensor

### DIFF
--- a/ai8x.py
+++ b/ai8x.py
@@ -477,28 +477,28 @@ class QuantizationAwareModule(nn.Module):
         self.bn = bn
         self.pooling = pooling
 
-        self.output_shift = nn.Parameter(torch.Tensor([0.]), requires_grad=False)
+        self.output_shift = nn.Parameter(torch.tensor([0.]), requires_grad=False)
         self.init_module(weight_bits, bias_bits, quantize_activation, shift_quantile)
 
     def init_module(self, weight_bits, bias_bits, quantize_activation, shift_quantile):
         """Initialize model parameters"""
         if weight_bits is None and bias_bits is None and not quantize_activation:
-            self.weight_bits = nn.Parameter(torch.Tensor([0]), requires_grad=False)
-            self.bias_bits = nn.Parameter(torch.Tensor([0]), requires_grad=False)
-            self.quantize_activation = nn.Parameter(torch.Tensor([False]), requires_grad=False)
-            self.adjust_output_shift = nn.Parameter(torch.Tensor([False]), requires_grad=False)
+            self.weight_bits = nn.Parameter(torch.tensor([0]), requires_grad=False)
+            self.bias_bits = nn.Parameter(torch.tensor([0]), requires_grad=False)
+            self.quantize_activation = nn.Parameter(torch.tensor([False]), requires_grad=False)
+            self.adjust_output_shift = nn.Parameter(torch.tensor([False]), requires_grad=False)
         elif weight_bits in [1, 2, 4, 8] and bias_bits in [1, 2, 4, 8] and quantize_activation:
-            self.weight_bits = nn.Parameter(torch.Tensor([weight_bits]), requires_grad=False)
-            self.bias_bits = nn.Parameter(torch.Tensor([bias_bits]), requires_grad=False)
-            self.quantize_activation = nn.Parameter(torch.Tensor([True]), requires_grad=False)
-            self.adjust_output_shift = nn.Parameter(torch.Tensor([not dev.simulate]),
+            self.weight_bits = nn.Parameter(torch.tensor([weight_bits]), requires_grad=False)
+            self.bias_bits = nn.Parameter(torch.tensor([bias_bits]), requires_grad=False)
+            self.quantize_activation = nn.Parameter(torch.tensor([True]), requires_grad=False)
+            self.adjust_output_shift = nn.Parameter(torch.tensor([not dev.simulate]),
                                                     requires_grad=False)
         else:
             assert False, f'Undefined mode with weight_bits: {weight_bits}, ' \
                           f'bias_bits: {bias_bits}, ' \
                           f'quantize_activation: {quantize_activation}'
 
-        self.shift_quantile = nn.Parameter(torch.Tensor([shift_quantile]), requires_grad=False)
+        self.shift_quantile = nn.Parameter(torch.tensor([shift_quantile]), requires_grad=False)
         self.set_functions()
 
     def set_functions(self):

--- a/ai8x_nas.py
+++ b/ai8x_nas.py
@@ -86,11 +86,11 @@ class OnceForAllModule(nn.Module):
                 assert False, f'Unknown operation for OFA module: {op}'
 
             # parameters to store in the checkpoint file
-            self.max_kernel_size = nn.Parameter(data=torch.Tensor(self.max_kernel_size),
+            self.max_kernel_size = nn.Parameter(data=torch.tensor(self.max_kernel_size),
                                                 requires_grad=False)
-            self.kernel_list = nn.Parameter(data=torch.Tensor(self.kernel_list),
+            self.kernel_list = nn.Parameter(data=torch.tensor(self.kernel_list),
                                             requires_grad=False)
-            self.padding_list = nn.Parameter(data=torch.Tensor(self.padding_list),
+            self.padding_list = nn.Parameter(data=torch.tensor(self.padding_list),
                                              requires_grad=False)
 
         self.init_module()

--- a/datasets/afsk.py
+++ b/datasets/afsk.py
@@ -84,7 +84,7 @@ class AFSK(Dataset):
             sampl /= _max - _min
 
         # 1d array -> 2d tensor
-        data = torch.tensor(sampl).unsqueeze(0)
+        data = torch.tensor(sampl, dtype=torch.float).unsqueeze(0)
 
         # apply transform, if any
         if self.transform:

--- a/datasets/afsk.py
+++ b/datasets/afsk.py
@@ -84,7 +84,7 @@ class AFSK(Dataset):
             sampl /= _max - _min
 
         # 1d array -> 2d tensor
-        data = torch.Tensor(sampl).unsqueeze(0)
+        data = torch.tensor(sampl).unsqueeze(0)
 
         # apply transform, if any
         if self.transform:

--- a/datasets/aisegment.py
+++ b/datasets/aisegment.py
@@ -63,7 +63,7 @@ class AISegment(Dataset):
     num_of_imgs_to_use_hr = 20000
 
     def __init__(self, root_dir, d_type, transform=None, im_size=(80, 80), fold_ratio=1,
-                 use_memory=False):
+                 use_memory=False, truncate_testset=False):
 
         if im_size not in ((80, 80), (352, 352)):
             raise ValueError('im_size can only be set to (80, 80) or (352, 352)')
@@ -87,6 +87,8 @@ class AISegment(Dataset):
             sys.exit()
 
         self.d_type = d_type
+
+        self.is_truncated = False
 
         vertical_crop_area = AISegment.org_img_dim[0] - AISegment.img_crp_dim[0]
 
@@ -201,13 +203,14 @@ class AISegment(Dataset):
             self.img_files_info = test_img_files_info
             self.dataset_pkl_file_path = test_dataset_pkl_file_path
             self.processed_folder_path = self.processed_test_data_folder
+            if truncate_testset:
+                self.is_truncated = True
 
         else:
             print(f'Unknown data type: {self.d_type}')
             return
 
         self.__create_pkl_files()
-        self.is_truncated = False
 
     def __create_pkl_files(self):
         if self.__check_pkl_files_exist():
@@ -407,7 +410,8 @@ def AISegment_get_datasets(data, load_train=True, load_test=True, im_size=(80, 8
 
         train_dataset = AISegment(root_dir=data_dir, d_type='train',
                                   transform=train_transform,
-                                  im_size=im_size, fold_ratio=fold_ratio, use_memory=use_memory)
+                                  im_size=im_size, fold_ratio=fold_ratio, use_memory=use_memory,
+                                  truncate_testset=False)
         print(f'Train dataset length: {len(train_dataset)}\n')
     else:
         train_dataset = None
@@ -420,7 +424,8 @@ def AISegment_get_datasets(data, load_train=True, load_test=True, im_size=(80, 8
 
         test_dataset = AISegment(root_dir=data_dir, d_type='test',
                                  transform=test_transform,
-                                 im_size=im_size, fold_ratio=fold_ratio, use_memory=use_memory)
+                                 im_size=im_size, fold_ratio=fold_ratio, use_memory=use_memory,
+                                 truncate_testset=args.truncate_testset)
 
         print(f'Test dataset length: {len(test_dataset)}\n')
     else:

--- a/datasets/vggface2.py
+++ b/datasets/vggface2.py
@@ -82,8 +82,8 @@ class VGGFace2Dataset(data.Dataset):
         embedding = np.expand_dims(embedding, 2)
         embedding *= 6.0
 
-        inp = torch.Tensor(self.__normalize_data(self.img_list[idx]))
+        inp = torch.tensor(self.__normalize_data(self.img_list[idx]))
         if self.transform is not None:
             inp = self.transform(inp)
 
-        return inp, torch.Tensor(embedding)
+        return inp, torch.tensor(embedding)

--- a/datasets/vggface2.py
+++ b/datasets/vggface2.py
@@ -82,8 +82,8 @@ class VGGFace2Dataset(data.Dataset):
         embedding = np.expand_dims(embedding, 2)
         embedding *= 6.0
 
-        inp = torch.tensor(self.__normalize_data(self.img_list[idx]))
+        inp = torch.tensor(self.__normalize_data(self.img_list[idx]), dtype=torch.float)
         if self.transform is not None:
             inp = self.transform(inp)
 
-        return inp, torch.tensor(embedding)
+        return inp, torch.tensor(embedding, dtype=torch.float)

--- a/datasets/youtube_faces.py
+++ b/datasets/youtube_faces.py
@@ -84,8 +84,8 @@ class YouTubeFacesDataset(data.Dataset):
         embedding = np.expand_dims(embedding, 2)
         embedding *= 6.0
 
-        inp = torch.tensor(self.__normalize_data(self.img_list[idx]))
+        inp = torch.tensor(self.__normalize_data(self.img_list[idx]), dtype=torch.float)
         if self.transform is not None:
             inp = self.transform(inp)
 
-        return inp, torch.tensor(embedding)
+        return inp, torch.tensor(embedding, dtype=torch.float)

--- a/datasets/youtube_faces.py
+++ b/datasets/youtube_faces.py
@@ -84,8 +84,8 @@ class YouTubeFacesDataset(data.Dataset):
         embedding = np.expand_dims(embedding, 2)
         embedding *= 6.0
 
-        inp = torch.Tensor(self.__normalize_data(self.img_list[idx]))
+        inp = torch.tensor(self.__normalize_data(self.img_list[idx]))
         if self.transform is not None:
             inp = self.transform(inp)
 
-        return inp, torch.Tensor(embedding)
+        return inp, torch.tensor(embedding)

--- a/notebooks/KWS_Audio_Evaluation.ipynb
+++ b/notebooks/KWS_Audio_Evaluation.ipynb
@@ -234,7 +234,7 @@
     "    plot: True to plot\n",
     "    \"\"\"\n",
     "    if fname[len(fname)-3:] == \"npy\":\n",
-    "        samples = torch.tensor(np.load(fname))\n",
+    "        samples = torch.tensor(np.load(fname), dtype=torch.float)\n",
     "\n",
     "        # In case it is a npy file that is 1-d, make it 2-d 128x128\n",
     "        if samples.shape[0] == 128*128:  # convert to 128x128\n",

--- a/notebooks/KWS_Audio_Evaluation.ipynb
+++ b/notebooks/KWS_Audio_Evaluation.ipynb
@@ -234,7 +234,7 @@
     "    plot: True to plot\n",
     "    \"\"\"\n",
     "    if fname[len(fname)-3:] == \"npy\":\n",
-    "        samples = torch.Tensor(np.load(fname))\n",
+    "        samples = torch.tensor(np.load(fname))\n",
     "\n",
     "        # In case it is a npy file that is 1-d, make it 2-d 128x128\n",
     "        if samples.shape[0] == 128*128:  # convert to 128x128\n",
@@ -775,7 +775,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.11"
+   "version": "3.8.10"
   }
  },
  "nbformat": 4,

--- a/train.py
+++ b/train.py
@@ -380,7 +380,7 @@ def main():
         if not args.regression:
             if 'weight' in selected_source:
                 criterion = nn.CrossEntropyLoss(
-                    torch.tensor(selected_source['weight'])
+                    torch.tensor(selected_source['weight'], dtype=torch.float)
                 ).to(args.device)
             else:
                 criterion = nn.CrossEntropyLoss().to(args.device)
@@ -1370,7 +1370,7 @@ def earlyexit_validate_loss(output, target, _criterion, args):
                 # take the results from early exit since lower than threshold
                 args.exiterrors[exitnum].add(
                     torch.tensor(
-                        np.array(output[exitnum].data[batch_index].cpu(), ndmin=2)
+                        np.array(output[exitnum].data[batch_index].cpu(), ndmin=2), dtype=torch.float
                     ),
                     torch.full([1], target[batch_index], dtype=torch.long))
                 args.exit_taken[exitnum] += 1
@@ -1381,7 +1381,7 @@ def earlyexit_validate_loss(output, target, _criterion, args):
             exitnum = args.num_exits - 1
             args.exiterrors[exitnum].add(
                 torch.tensor(
-                    np.array(output[exitnum].data[batch_index].cpu(), ndmin=2)
+                    np.array(output[exitnum].data[batch_index].cpu(), ndmin=2), dtype=torch.float
                 ),
                 torch.full([1], target[batch_index], dtype=torch.long))
             args.exit_taken[exitnum] += 1

--- a/train.py
+++ b/train.py
@@ -1614,7 +1614,7 @@ def create_activation_stats_collectors(model, *phases):
     """
     distiller.utils.assign_layer_fq_names(model)
 
-    def genCollectors(): return missingdict({  # noqa E731 pylint: disable=unnecessary-lambda-assignment
+    genCollectors = lambda: missingdict({ # noqa E731 pylint: disable=unnecessary-lambda-assignment
         "sparsity":      SummaryActivationStatsCollector(model, "sparsity",
                                                          lambda t:
                                                          100 * distiller.utils.sparsity(t)),

--- a/train.py
+++ b/train.py
@@ -470,7 +470,7 @@ def main():
 
     if args.nas:
         assert isinstance(model, ai8x_nas.OnceForAllModel), 'Model should implement ' \
-                                        'OnceForAllModel interface for NAS training!'
+            'OnceForAllModel interface for NAS training!'
         if nas_policy:
             args.nas_stage_transition_list = create_nas_training_stage_list(model, nas_policy)
             # pylint: disable=unsubscriptable-object
@@ -775,7 +775,7 @@ def train(train_loader, model, criterion, optimizer, epoch,
                 # calculation last two batches are used as the last batch might include just a few
                 # samples.
                 if args.show_train_accuracy == 'full' or \
-                       (args.show_train_accuracy == 'last_batch'
+                    (args.show_train_accuracy == 'last_batch'
                         and train_step >= len(train_loader)-2):
                     if len(output.data.shape) <= 2 or args.regression:
                         classerr.add(output.data, target)
@@ -1370,8 +1370,8 @@ def earlyexit_validate_loss(output, target, _criterion, args):
                 # take the results from early exit since lower than threshold
                 args.exiterrors[exitnum].add(
                     torch.tensor(
-                        np.array(output[exitnum].data[batch_index].cpu(), ndmin=2), dtype=torch.float
-                    ),
+                        np.array(output[exitnum].data[batch_index].cpu(), ndmin=2),
+                        dtype=torch.float),
                     torch.full([1], target[batch_index], dtype=torch.long))
                 args.exit_taken[exitnum] += 1
                 earlyexit_taken = True
@@ -1594,6 +1594,7 @@ def get_next_stage_start_epoch(epoch, stage_transition_list, num_epochs):
 
 class missingdict(dict):
     """This is a little trick to prevent KeyError"""
+
     def __missing__(self, key):
         return None  # note, does *not* set self[key] - we don't want defaultdict's behavior
 
@@ -1613,7 +1614,7 @@ def create_activation_stats_collectors(model, *phases):
     """
     distiller.utils.assign_layer_fq_names(model)
 
-    genCollectors = lambda: missingdict({  # noqa E731 pylint: disable=unnecessary-lambda-assignment
+    def genCollectors(): return missingdict({  # noqa E731 pylint: disable=unnecessary-lambda-assignment
         "sparsity":      SummaryActivationStatsCollector(model, "sparsity",
                                                          lambda t:
                                                          100 * distiller.utils.sparsity(t)),

--- a/train.py
+++ b/train.py
@@ -915,11 +915,11 @@ def test(test_loader, model, criterion, loggers, activations_collectors, args):
             with torch.no_grad():
                 global weight_min, weight_max, weight_count  # pylint: disable=global-statement
                 global weight_sum, weight_stddev, weight_mean  # pylint: disable=global-statement
-                weight_min = torch.tensor(float('inf'))
-                weight_max = torch.tensor(float('-inf'))
-                weight_count = torch.tensor(0, dtype=torch.int)
-                weight_sum = torch.tensor(0.0)
-                weight_stddev = torch.tensor(0.0)
+                weight_min = torch.tensor(float('inf')).to(args.device)
+                weight_max = torch.tensor(float('-inf')).to(args.device)
+                weight_count = torch.tensor(0, dtype=torch.int).to(args.device)
+                weight_sum = torch.tensor(0.0).to(args.device)
+                weight_stddev = torch.tensor(0.0).to(args.device)
 
                 def traverse_pass1(m):
                     """

--- a/train.py
+++ b/train.py
@@ -1371,7 +1371,7 @@ def earlyexit_validate_loss(output, target, _criterion, args):
                 args.exiterrors[exitnum].add(
                     torch.tensor(
                         np.array(output[exitnum].data[batch_index].cpu(), ndmin=2),
-                            dtype=torch.float
+                        dtype=torch.float
                         ),
                     torch.full([1], target[batch_index], dtype=torch.long))
                 args.exit_taken[exitnum] += 1
@@ -1383,7 +1383,7 @@ def earlyexit_validate_loss(output, target, _criterion, args):
             args.exiterrors[exitnum].add(
                 torch.tensor(
                     np.array(output[exitnum].data[batch_index].cpu(), ndmin=2),
-                        dtype=torch.float
+                    dtype=torch.float
                 ),
                 torch.full([1], target[batch_index], dtype=torch.long))
             args.exit_taken[exitnum] += 1

--- a/train.py
+++ b/train.py
@@ -1371,7 +1371,8 @@ def earlyexit_validate_loss(output, target, _criterion, args):
                 args.exiterrors[exitnum].add(
                     torch.tensor(
                         np.array(output[exitnum].data[batch_index].cpu(), ndmin=2),
-                        dtype=torch.float),
+                            dtype=torch.float
+                        ),
                     torch.full([1], target[batch_index], dtype=torch.long))
                 args.exit_taken[exitnum] += 1
                 earlyexit_taken = True
@@ -1381,7 +1382,8 @@ def earlyexit_validate_loss(output, target, _criterion, args):
             exitnum = args.num_exits - 1
             args.exiterrors[exitnum].add(
                 torch.tensor(
-                    np.array(output[exitnum].data[batch_index].cpu(), ndmin=2), dtype=torch.float
+                    np.array(output[exitnum].data[batch_index].cpu(), ndmin=2),
+                        dtype=torch.float
                 ),
                 torch.full([1], target[batch_index], dtype=torch.long))
             args.exit_taken[exitnum] += 1
@@ -1614,7 +1616,7 @@ def create_activation_stats_collectors(model, *phases):
     """
     distiller.utils.assign_layer_fq_names(model)
 
-    genCollectors = lambda: missingdict({ # noqa E731 pylint: disable=unnecessary-lambda-assignment
+    genCollectors = lambda: missingdict({  # noqa E731 pylint: disable=unnecessary-lambda-assignment
         "sparsity":      SummaryActivationStatsCollector(model, "sparsity",
                                                          lambda t:
                                                          100 * distiller.utils.sparsity(t)),

--- a/train.py
+++ b/train.py
@@ -380,7 +380,7 @@ def main():
         if not args.regression:
             if 'weight' in selected_source:
                 criterion = nn.CrossEntropyLoss(
-                    torch.Tensor(selected_source['weight'])
+                    torch.tensor(selected_source['weight'])
                 ).to(args.device)
             else:
                 criterion = nn.CrossEntropyLoss().to(args.device)
@@ -915,11 +915,11 @@ def test(test_loader, model, criterion, loggers, activations_collectors, args):
             with torch.no_grad():
                 global weight_min, weight_max, weight_count  # pylint: disable=global-statement
                 global weight_sum, weight_stddev, weight_mean  # pylint: disable=global-statement
-                weight_min = torch.Tensor(float('inf'))
-                weight_max = torch.Tensor(float('-inf'))
-                weight_count = torch.Tensor(0, dtype=torch.int)
-                weight_sum = torch.Tensor(0.0)
-                weight_stddev = torch.Tensor(0.0)
+                weight_min = torch.tensor(float('inf'))
+                weight_max = torch.tensor(float('-inf'))
+                weight_count = torch.tensor(0, dtype=torch.int)
+                weight_sum = torch.tensor(0.0)
+                weight_stddev = torch.tensor(0.0)
 
                 def traverse_pass1(m):
                     """
@@ -1369,7 +1369,7 @@ def earlyexit_validate_loss(output, target, _criterion, args):
             if args.loss_exits[exitnum][batch_index] < args.earlyexit_thresholds[exitnum]:
                 # take the results from early exit since lower than threshold
                 args.exiterrors[exitnum].add(
-                    torch.Tensor(
+                    torch.tensor(
                         np.array(output[exitnum].data[batch_index].cpu(), ndmin=2)
                     ),
                     torch.full([1], target[batch_index], dtype=torch.long))
@@ -1380,7 +1380,7 @@ def earlyexit_validate_loss(output, target, _criterion, args):
         if not earlyexit_taken:
             exitnum = args.num_exits - 1
             args.exiterrors[exitnum].add(
-                torch.Tensor(
+                torch.tensor(
                     np.array(output[exitnum].data[batch_index].cpu(), ndmin=2)
                 ),
                 torch.full([1], target[batch_index], dtype=torch.long))


### PR DESCRIPTION
torch.Tensor was split into torch.tensor and torch.empty. To convert a variable to a tensor, now torch.tensor should be used. 