### PR TITLE
Improve calculation speed for object detection models

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ADI MAX78000/MAX78002 Model Training and Synthesis
 
-April 5, 2023
+June 14, 2023
 
 ADI’s MAX78000/MAX78002 project is comprised of five repositories:
 
@@ -60,7 +60,7 @@ PyTorch operating system and hardware support are constantly evolving. This docu
 
 Full support and documentation are provided for the following platform:
 
-* CPU: 64-bit amd64/x86_64 “PC” with [Ubuntu Linux 20.04 LTS/22.04 LTS](https://ubuntu.com/download/server)
+* CPU: 64-bit amd64/x86_64 “PC” with [Ubuntu Linux 20.04 LTS or 22.04 LTS](https://ubuntu.com/download/server)
 * GPU for hardware acceleration (optional but highly recommended): Nvidia with [CUDA 11](https://developer.nvidia.com/cuda-toolkit-archive)
 * [PyTorch 1.8.1 (LTS)](https://pytorch.org/get-started/locally/) on Python 3.8.x
 
@@ -1330,11 +1330,11 @@ If hardware acceleration is not available, skip the following two steps and cont
 
 The main training software is `train.py`. It drives the training aspects, including model creation, checkpointing, model save, and status display (see `--help` for the many supported options, and the `scripts/train_*.sh` scripts for example usage).
 
-The `ai84net.py` and `ai85net.py` files contain models that fit into AI84’s weight memory. These models rely on the MAX78000/MAX78002 hardware operators that are defined in `ai8x.py`.
+The `models/` folder contains models that fit into the MAX78000 or MAX78002’s weight memory. These models rely on the MAX78000/MAX78002 hardware operators that are defined in `ai8x.py`.
 
 To train the FP32 model for MNIST on MAX78000 or MAX78002, run `scripts/train_mnist.sh` from the `ai8x-training` project. This script will place checkpoint files into the log directory. Training makes use of the Distiller framework, but the `train.py` software has been modified slightly to improve it and add some MAX78000/MAX78002 specifics.
 
-Since training can take hours or days, the training script does not overwrite any weights previously produced. Results are placed in sub-directories under `logs/` named with the date and time when training began. The latest results are always soft-linked to by `latest-log_dir` and `latest_log_file`.
+Since training can take a significant amount of time, the training script does not overwrite any weights previously produced. Results are placed in sub-directories under `logs/` named with the date and time when training began. The latest results are always soft-linked to by `latest-log_dir` and `latest_log_file`.
 
 #### Troubleshooting
 
@@ -1345,6 +1345,9 @@ Since training can take hours or days, the training script does not overwrite an
    ```shell
    $ scripts/train_mnist.sh --workers=1
    ```
+
+3. On resource constrained systems, training may abort with an error message such as `RuntimeError: unable to open shared memory object </torch_..._...> in read-write mode`. Add `--workers=0` when running the training script.
+
 
 ### Example Training Session
 
@@ -1591,8 +1594,8 @@ The following modules are predefined:
 | FusedConv1dAbs         | Conv1d, followed by Abs                 |
 | MaxPool1d | MaxPool1d |
 | FusedMaxPoolConv1d | MaxPool1d, followed by Conv1d |
-| FusedMaxPoolConv1dReLU | MaxPool2d, followed by Conv1d, and ReLU |
-| FusedMaxPoolConv1dAbs | MaxPool2d, followed by Conv1d, and Abs |
+| FusedMaxPoolConv1dReLU | MaxPool1d, followed by Conv1d, and ReLU |
+| FusedMaxPoolConv1dAbs | MaxPool1d, followed by Conv1d, and Abs |
 | AvgPool1d | AvgPool1d |
 | FusedAvgPoolConv1d | AvgPool1d, followed by Conv1d |
 | FusedAvgPoolConv1dReLU | AvgPool1d, followed by Conv1d, and ReLU |

--- a/datasets/svhn.py
+++ b/datasets/svhn.py
@@ -443,8 +443,6 @@ def SVHN_get_datasets(data, load_train=True, load_test=True, resize_size=(96, 96
         train_dataset = SVHN(root_dir=data_dir, d_type='train',
                              transform=train_transform, resize_size=resize_size,
                              fold_ratio=fold_ratio, simplified=simplified)
-
-        print(f'Train dataset length: {len(train_dataset)}\n')
     else:
         train_dataset = None
 
@@ -455,8 +453,6 @@ def SVHN_get_datasets(data, load_train=True, load_test=True, resize_size=(96, 96
         test_dataset = SVHN(root_dir=data_dir, d_type='test',
                             transform=test_transform, resize_size=resize_size,
                             fold_ratio=fold_ratio, simplified=simplified)
-
-        print(f'Test dataset length: {len(test_dataset)}\n')
     else:
         test_dataset = None
 

--- a/requirements-cu11.txt
+++ b/requirements-cu11.txt
@@ -14,7 +14,8 @@ numba<0.50.0
 opencv-python>=4.4.0
 pytsmod>=0.3.3
 h5py>=3.7.0
-torchmetrics>=0.11.4
+torchmetrics==0.6.0
+pycocotools==2.0.6
 albumentations>=1.3.0
 pytube>=12.1.3
 pyffmpeg==2.0

--- a/requirements-win-cu11.txt
+++ b/requirements-win-cu11.txt
@@ -14,7 +14,8 @@ numba<0.50.0
 opencv-python>=4.4.0
 pytsmod>=0.3.3
 h5py>=3.7.0
-torchmetrics>=0.11.4
+torchmetrics==0.6.0
+pycocotools==2.0.6
 albumentations>=1.3.0
 pytube>=12.1.3
 pyffmpeg==2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,8 @@ numba<0.50.0
 opencv-python>=4.4.0
 pytsmod>=0.3.3
 h5py>=3.7.0
-torchmetrics>=0.11.4
+torchmetrics==0.6.0
+pycocotools==2.0.6
 albumentations>=1.3.0
 pytube>=12.1.3
 pyffmpeg==2.0

--- a/train.py
+++ b/train.py
@@ -96,7 +96,7 @@ from distiller.data_loggers.collector import (QuantCalibrationStatsCollector,
                                               RecordsActivationStatsCollector,
                                               SummaryActivationStatsCollector, collectors_context)
 from distiller.quantization.range_linear import PostTrainLinearQuantizer
-from torchmetrics.detection.mean_ap import MeanAveragePrecision
+from torchmetrics.detection import MAP as MeanAveragePrecision
 
 # pylint: enable=no-name-in-module
 import ai8x
@@ -366,10 +366,9 @@ def main():
 
         # .module is added to model for access in multi GPU environments
         # as https://github.com/pytorch/pytorch/issues/16885 has not been merged yet
-        if isinstance(model, nn.DataParallel):
-            model = model.module
+        m = model.module if isinstance(model, nn.DataParallel) else model
 
-        criterion = MultiBoxLoss(priors_cxcy=model.priors_cxcy,
+        criterion = MultiBoxLoss(priors_cxcy=m.priors_cxcy,
                                  alpha=obj_detection_params['multi_box_loss']['alpha'],
                                  neg_pos_ratio=obj_detection_params['multi_box_loss']
                                  ['neg_pos_ratio'], device=args.device).to(args.device)
@@ -835,7 +834,7 @@ def train(train_loader, model, criterion, optimizer, epoch,
 
         # measure elapsed time
         batch_time.add(time.time() - end)
-        steps_completed = (train_step+1)
+        steps_completed = train_step + 1
 
         if steps_completed % args.print_freq == 0 or steps_completed == steps_per_epoch:
             # Log some statistics
@@ -969,8 +968,12 @@ def _validate(data_loader, model, criterion, loggers, args, epoch=-1, tflogger=N
     """Execute the validation/test loop."""
     losses = {'objective_loss': tnt.AverageValueMeter()}
     if args.obj_detection:
-        map_calculator = MeanAveragePrecision(box_format='xyxy', iou_type='bbox',
-                                              class_metrics=False, iou_thresholds=[0.5])
+        map_calculator = MeanAveragePrecision(
+            # box_format='xyxy',  # Enable in torchmetrics > 0.6
+            # iou_type='bbox',  # Enable in torchmetrics > 0.6
+            class_metrics=False,
+            # iou_thresholds=[0.5],  # Enable in torchmetrics > 0.6
+        )
         mAP = 0.00
     if not args.regression:
         classerr = tnt.ClassErrorMeter(accuracy=True, topk=(1, min(args.num_classes, 5)))
@@ -1034,31 +1037,23 @@ def _validate(data_loader, model, criterion, loggers, args, epoch=-1, tflogger=N
     obj_detection_params = parse_obj_detection_yaml.parse(args.obj_detection_params) \
         if args.obj_detection_params else None
 
-    for validation_step, (inputs, target) in enumerate(data_loader):
-
-        with torch.no_grad():
-
+    mAP = 0.0
+    have_mAP = False
+    with torch.no_grad():
+        for validation_step, (inputs, target) in enumerate(data_loader):
             if args.obj_detection:
-
                 if not object_detection_utils.check_target_exists(target):
                     print(f'No target in batch. Ep: {epoch}, validation_step: {validation_step}')
                     continue
 
-                boxes_list = [elem[0] for elem in target]
-                labels_list = [elem[1] for elem in target]
+                boxes_list = [elem[0].to(args.device) for elem in target]
+                labels_list = [elem[1].to(args.device) for elem in target]
+                filtered_all_images_boxes = None
 
                 # Adjust ground truth index as mAP calculator uses 0-indexed class labels
-                labels_list_for_map = [elem[1] - 1 for elem in target]
-
-                difficulties = []
-                for label_objects in labels_list:
-                    difficulties.append(torch.zeros_like(label_objects))
+                labels_list_for_map = [elem[1].to(args.device) - 1 for elem in target]
 
                 inputs = inputs.to(args.device)
-                boxes_list = [boxes.to(args.device) for boxes in boxes_list]
-                labels_list = [labels.to(args.device) for labels in labels_list]
-                labels_list_for_map = [labels.to(args.device) for labels in labels_list_for_map]
-                difficulties = [d.to(args.device) for d in difficulties]
 
                 target = (boxes_list, labels_list)
 
@@ -1080,52 +1075,41 @@ def _validate(data_loader, model, criterion, loggers, args, epoch=-1, tflogger=N
 
                 # .module is added to model for access in multi GPU environments
                 # as https://github.com/pytorch/pytorch/issues/16885 has not been merged yet
-                if isinstance(model, nn.DataParallel):
-                    model = model.module
+                m = model.module if isinstance(model, nn.DataParallel) else model
 
                 det_boxes_batch, det_labels_batch, det_scores_batch = \
-                    model.detect_objects(output_boxes, output_conf,
-                                         min_score=obj_detection_params['nms']['min_score'],
-                                         max_overlap=obj_detection_params['nms']['max_overlap'],
-                                         top_k=obj_detection_params['nms']['top_k'])
+                    m.detect_objects(output_boxes, output_conf,
+                                     min_score=obj_detection_params['nms']['min_score'],
+                                     max_overlap=obj_detection_params['nms']['max_overlap'],
+                                     top_k=obj_detection_params['nms']['top_k'])
 
                 # Filter images with only background box
-                filtered_images_boxes_labels_scores = \
-                    list(filter(lambda elem: not (len(elem[1]) == 1 and elem[1][0] == 0),
-                                zip(det_boxes_batch, det_labels_batch, det_scores_batch)))
-
-                filtered_all_images_boxes = [elem[0]
-                                             for elem in filtered_images_boxes_labels_scores]
-
-                # Adjust detected label index as mAP calculator uses 0-indexed class labels
-                filtered_all_images_labels = [
-                    elem[1] - 1 for elem in filtered_images_boxes_labels_scores]
-                filtered_all_images_scores = [elem[2]
-                                              for elem in filtered_images_boxes_labels_scores]
+                filtered_all_images_boxes, \
+                    filtered_all_images_labels, filtered_all_images_scores = \
+                    zip(*list(filter(lambda elem: not (len(elem[1]) == 1 and elem[1][0] == 0),
+                                     zip(det_boxes_batch, det_labels_batch, det_scores_batch))))
 
                 # Update mAP Calculator
                 if boxes_list and filtered_all_images_boxes:
+                    # mAP calculator uses 0-indexed class labels
+                    filtered_all_images_labels = [e - 1 for e in filtered_all_images_labels]
 
                     # Prepare truths
                     boxes = torch.cat(boxes_list)
                     labels = torch.cat(labels_list_for_map)
 
-                    gt = [dict(boxes=boxes, labels=labels)]
+                    gt = [{'boxes': boxes, 'labels': labels}]
 
                     # Prepare predictions
                     pred_boxes = torch.cat(filtered_all_images_boxes)
                     pred_scores = torch.cat(filtered_all_images_scores)
                     pred_labels = torch.cat(filtered_all_images_labels)
 
-                    preds = [dict(boxes=pred_boxes, scores=pred_scores, labels=pred_labels)]
+                    preds = [{'boxes': pred_boxes, 'scores': pred_scores, 'labels': pred_labels}]
 
                     # Update mAP calculator
                     map_calculator.update(preds=preds, target=gt)
-
-                    # Keep latest value
-                    mAPs = {"val_" + k: v for k, v in map_calculator.compute().items()}
-                    mAP = mAPs["val_map_50"]
-
+                    have_mAP = True
             else:
                 inputs, target = inputs.to(args.device), target.to(args.device)
                 # compute output from model
@@ -1174,7 +1158,7 @@ def _validate(data_loader, model, criterion, loggers, args, epoch=-1, tflogger=N
             batch_time.add(time.time() - end)
             end = time.time()
 
-            steps_completed = (validation_step+1)
+            steps_completed = validation_step + 1
             if steps_completed % args.print_freq == 0 or steps_completed == total_steps:
                 if args.display_prcurves and tflogger is not None:
                     # TODO PR Curve generation for Object Detection case is NOT implemented yet
@@ -1184,8 +1168,12 @@ def _validate(data_loader, model, criterion, loggers, args, epoch=-1, tflogger=N
                     class_preds.append(class_preds_batch)
 
                 if not args.earlyexit_thresholds:
-
                     if args.obj_detection:
+                        # Only run compute() if there is at least one new update()
+                        if have_mAP:
+                            # Remove [0] in new torchmetrics
+                            mAP = map_calculator.compute()['map_50'][0]
+                            have_mAP = False
                         stats = (
                             '',
                             OrderedDict([('Loss', losses['objective_loss'].mean),
@@ -1546,7 +1534,7 @@ def summarize_model(model, dataset, which_summary, filename='model'):
         model_summaries.draw_img_classifier_to_file(model, filename + '.png', dataset,
                                                     which_summary == 'png_w_params')
     elif which_summary in ['onnx', 'onnx_simplified']:
-        ai8x.onnx_export_prep(model, simplify=(which_summary == 'onnx_simplified'))
+        ai8x.onnx_export_prep(model, simplify=which_summary == 'onnx_simplified')
         model_summaries.export_img_classifier_to_onnx(
             model,
             filename + '.onnx',


### PR DESCRIPTION
- Run mAP compute() only when needed (~200x speedup)
- Use torchmetrics 0.6.0 (~ 10x speedup)
- Enable multi-GPU training (mAP calculation is single GPU at this time)