### PR TITLE
Fix QAT resume with BN models, checkpoint name

### DIFF
--- a/train.py
+++ b/train.py
@@ -347,6 +347,10 @@ def main():
             # pylint: disable=unsubscriptable-object
             if checkpoint.get('epoch', None) >= qat_policy['start_epoch']:
                 ai8x.fuse_bn_layers(model)
+                if args.name:
+                    args.name = f'{args.name}_qat'
+                else:
+                    args.name = 'qat'
             # pylint: enable=unsubscriptable-object
         model, compression_scheduler, optimizer, start_epoch = apputils.load_checkpoint(
             model, args.resumed_checkpoint_path, model_device=args.device)
@@ -359,6 +363,10 @@ def main():
             # pylint: disable=unsubscriptable-object
             if checkpoint.get('epoch', None) >= qat_policy['start_epoch']:
                 ai8x.fuse_bn_layers(model)
+                if args.name:
+                    args.name = f'{args.name}_qat'
+                else:
+                    args.name = 'qat'
             # pylint: enable=unsubscriptable-object
         model = apputils.load_lean_checkpoint(model, args.load_model_path,
                                               model_device=args.device)
@@ -512,6 +520,9 @@ def main():
 
             # Fuse the BN parameters into conv layers before Quantization Aware Training (QAT)
             ai8x.fuse_bn_layers(model)
+
+            # Update the optimizer to reflect fused batchnorm layers
+            optimizer = ai8x.update_optimizer(model, optimizer)
 
             # Switch model from unquantized to quantized for QAT
             ai8x.initiate_qat(model, qat_policy)


### PR DESCRIPTION
I noticed these bugs recently and this pr is independent of the bug fixes and updates I mentioned in last week's meeting.

![image](https://github.com/MaximIntegratedAI/ai8x-training/assets/80602263/c1af1cb3-05ff-41e7-a734-2127a239973c)

When resuming a checkpoint, a new optimizer is created from the model. As batchnorm fusing reduces models' parameter sizes, when resuming from a qat_checkpoint new optimizer have less parameters than the optimizer state_dict at the checkpoint.
Therefore, I added a update_optimizer function to call at initiate_qat state to strip off the batchnorm parameters from the optimizer. 

Also, after resuming a qat_checkpoint, checkpoint names were incorrect. This pr includes a simple fix for that as well.

Limitations:
- This solution is tested for a single params_group case. As our current train.py structure always produces a single params_group, it should be okay.  However, if we ever add functionality to have different learning rates for different layers, we should check this function as well.


