### PR TITLE
Update evaluation scripts

### DIFF
--- a/scripts/evaluate_cifar100_effnet2.sh
+++ b/scripts/evaluate_cifar100_effnet2.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-python train.py --model ai87effnetv2 --dataset CIFAR100 --evaluate --device MAX78000 --exp-load-weights-from ../ai8x-synthesis/trained/ai87-cifar100-effnet2-qat8-q.pth.tar -8 --use-bias "$@"
+python train.py --model ai87effnetv2 --dataset CIFAR100 --evaluate --device MAX78002 --exp-load-weights-from ../ai8x-synthesis/trained/ai87-cifar100-effnet2-qat8-q.pth.tar -8 --use-bias "$@"

--- a/scripts/evaluate_cifar100_mobilenet_v2_0.5.sh
+++ b/scripts/evaluate_cifar100_mobilenet_v2_0.5.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-python train.py --model ai87netmobilenetv2cifar100_m0_5 --dataset CIFAR100 --evaluate --device MAX78000 --exp-load-weights-from ../ai8x-synthesis/trained/ai87-cifar100-mobilenet-v2-0.5-qat8-q.pth.tar -8 --use-bias "$@"
+python train.py --model ai87netmobilenetv2cifar100_m0_5 --dataset CIFAR100 --evaluate --device MAX78002 --exp-load-weights-from ../ai8x-synthesis/trained/ai87-cifar100-mobilenet-v2-0.5-qat8-q.pth.tar -8 --use-bias "$@"

--- a/scripts/evaluate_cifar100_mobilenet_v2_0.75.sh
+++ b/scripts/evaluate_cifar100_mobilenet_v2_0.75.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-python train.py --model ai87netmobilenetv2cifar100_m0_75 --dataset CIFAR100 --evaluate --device MAX78000 --exp-load-weights-from ../ai8x-synthesis/trained/ai87-cifar100-mobilenet-v2-0.75-qat8-q.pth.tar -8 --use-bias "$@"
+python train.py --model ai87netmobilenetv2cifar100_m0_75 --dataset CIFAR100 --evaluate --device MAX78002 --exp-load-weights-from ../ai8x-synthesis/trained/ai87-cifar100-mobilenet-v2-0.75-qat8-q.pth.tar -8 --use-bias "$@"

--- a/scripts/evaluate_cifar10_1x1.sh
+++ b/scripts/evaluate_cifar10_1x1.sh
@@ -1,2 +1,0 @@
-#!/bin/sh
-python train.py --model ai85net6 --dataset CIFAR10 --confusion --evaluate --device MAX78000 --exp-load-weights-from ../ai8x-synthesis/trained/ai85-cifar10-1x1.pth.tar -8 "$@"

--- a/scripts/evaluate_imagenet_effnet2.sh
+++ b/scripts/evaluate_imagenet_effnet2.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-python train.py --model ai87imageneteffnetv2 --dataset ImageNet --evaluate --device MAX78002 --exp-load-weights-from ../ai8x-synthesis/trained/ai87-imagenet-effnet2-q.pth.tar -8 --use-bias "$@"
+python train.py --model ai87imageneteffnetv2 --dataset ImageNet --evaluate --device MAX78002 --exp-load-weights-from ../ai8x-synthesis/trained/ai87-imagenet-effnet2-q.pth.tar -8 --use-bias --qat-policy policies/qat_policy_imagenet.yaml "$@"


### PR DESCRIPTION
1. AssertionError: Set device to MAX78002 for depthwise support fixed for "scripts/evaluate_cifar100_effnet2.sh", "scripts/evaluate_cifar100_mobilenet_v2_0.5.sh", and "scripts/evaluate_cifar100_mobilenet_v2_0.75.sh"
2. Deleted "scripts/evaluate_cifar10_1x1.sh" because no such file or directory: './ai8x-synthesis/trained/ai85-cifar10-1x1.pth.tar'
3. Missing qat policy added to "scripts/evaluate_imagenet_effnet2.sh"