### PR TITLE
Improvements in `yamlwriter` and fused layers

### DIFF
--- a/ai8x.py
+++ b/ai8x.py
@@ -1634,7 +1634,7 @@ class FusedMaxPoolConv1dAbs(FusedMaxPoolConv1d):
         super().__init__(*args, activation='Abs', **kwargs)
 
 
-class FusedMaxPoolConv1dBNAbs(FusedMaxPoolConv1d):
+class FusedMaxPoolConv1dBNAbs(FusedMaxPoolConv1dAbs):
     """
     Fused 1D Max Pool, 1D Convolution, BatchNorm and Abs
     """
@@ -1687,7 +1687,7 @@ class FusedAvgPoolConv1dAbs(FusedAvgPoolConv1d):
         super().__init__(*args, activation='Abs', **kwargs)
 
 
-class FusedAvgPoolConv1dBNAbs(FusedAvgPoolConv1d):
+class FusedAvgPoolConv1dBNAbs(FusedAvgPoolConv1dAbs):
     """
     Fused 1D Avg Pool, 1D Convolution, BatchNorm and Abs
     """

--- a/yamlwriter.py
+++ b/yamlwriter.py
@@ -142,8 +142,8 @@ def create(
         separator = s.rfind('.')
         if separator > 0:
             if s[separator + 1:] == 'op':
-                return s[:separator]
-        return s
+                s = s[:separator]
+        return f'layer_{s}' if s.isnumeric() else s
 
     def ignore_layer(
             _name: str,

--- a/yamlwriter.py
+++ b/yamlwriter.py
@@ -18,11 +18,13 @@ TODO: Testing
 NOTE: This code partially depends on ai8x.py:
       - Quantization information is expected in '.weight_bits'.
 """
+import argparse
 import os
 import warnings
 from typing import Any, Callable, Dict, List, Optional, OrderedDict, Tuple, Union
 
 import distiller
+import torch
 
 import ai8x
 import devices
@@ -1236,3 +1238,30 @@ def create(
                 f.write('\n')
 
             prev_name = name
+
+
+if __name__ == "__main__":
+    parser =argparse.ArgumentParser("YAML configuration generator")
+    parser.add_argument("--model-path", type=str, required=True, help="Path to the model")
+    parser.add_argument("--arch", type=str, default="custom", help="Model architecture")
+    parser.add_argument("--device-id", type=int, default=None, help="Device id")
+    parser.add_argument("--input-shape", type=str, required=True, help="Model input shape, i.e. 3,28,28")
+    parser.add_argument("--output-path", type=str, required=True, help="Output YAML path")
+
+    args = parser.parse_args()
+
+    input_shape = list(map(int, args.input_shape.split(',')))
+
+    # see: https://github.com/analogdevicesinc/ai8x-training/blob/main/train.py#L691-L695
+    distiller.utils._validate_input_shape = lambda _a, _b: input_shape
+
+    ai8x.set_device(args.device_id, False, False)
+
+    model = torch.load(args.model_path, weights_only=False)
+
+    create(
+        model=model,
+        dataset="unknown",
+        arch=args.arch,
+        filename=args.output_path,
+    )


### PR DESCRIPTION
This PR fixes/adds several things:
* sets correct base classes for fused layers: `FusedMaxPoolConv1dBNAbs` and `FusedAvgPoolConv1dBNAbs`. The previous ones missed activation.
* adds option to run `yamlwriter` as a separate script to allow running it without training pipeline.
* converts layer names to string in `yamlwriter` as for sequential models those are integers. It leads to issues in yamlwriter, since it tries to call string methods on names.