### PR TITLE
Split requirements into multiple files

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -1,0 +1,14 @@
+torch==2.3.1
+torchvision==0.18.1
+GitPython==3.1.43
+Pillow==10.4.0
+PyYAML==6.0.1
+faiss-cpu==1.8.0.post1
+numpy==1.26.4
+pytorch-metric-learning==2.6.0
+seaborn==0.13.2
+scipy==1.14.0
+tensorboard==2.17.0
+tk==0.1.0
+torchmetrics==1.4.0.post0
+torchnet==0.0.4

--- a/requirements-datasets.txt
+++ b/requirements-datasets.txt
@@ -1,0 +1,11 @@
+albumentations==1.4.15
+albucore==0.0.16
+batch-face==1.4.0
+h5py==3.11.0
+kornia==0.7.3
+opencv-python==4.10.0.84
+pyffmpeg==2.4.2.18.1
+pytube==15.0.0
+soundfile==0.12.1
+qrcode==7.4.2
+torchaudio==2.3.1

--- a/requirements-distiller.txt
+++ b/requirements-distiller.txt
@@ -1,0 +1,2 @@
+pycocotools==2.0.8
+-e distiller --config-settings editable_mode=strict

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,27 +1,3 @@
-torch==2.3.1
-torchvision==0.18.1
-torchaudio==2.3.1
-GitPython==3.1.43
-Pillow==10.4.0
-PyYAML==6.0.1
-albumentations==1.4.15
-albucore==0.0.16
-faiss-cpu==1.8.0.post1
-batch-face==1.4.0
-h5py==3.11.0
-kornia==0.7.3
-numpy==1.26.4
-opencv-python==4.10.0.84
-pycocotools==2.0.8
-pyffmpeg==2.4.2.18.1
-pytorch-metric-learning==2.6.0
-pytube==15.0.0
-qrcode==7.4.2
-seaborn==0.13.2
-scipy==1.14.0
-soundfile==0.12.1
-tensorboard==2.17.0
-tk==0.1.0
-torchmetrics==1.4.0.post0
-torchnet==0.0.4
--e distiller --config-settings editable_mode=strict
+-r requirements-base.txt
+-r requirements-datasets.txt
+-r requirements-distiller.txt


### PR DESCRIPTION
This pull request splits the requirements.txt file into multiple files based on what functionality of the repository they enable.

The motivations are the following:
* Isolate the `pyffmpeg==2.4.2.18.1` dependency, which has been removed from PyPi. (Mitigates the effect of the problem, doesn't address the root cause).
* Allow for certain functionality of the repository to persist even if other dependencies were to become unavailable. e.g. if pytube were to be removed from PyPi, only flows which require the acquisition of datasets would break. This diminishes the effect of issues like the one that affected pyffmpeg.
* Allow for the possibility of installing only the required dependencies for a certain use-case. Decreases installation time, reduces complexity of the environment.


Here's the list of requirements files:

* requirements.txt: file is preserved, and installs the same set of dependencies. Represents the whole of the dependencies in the repository. Instructs pip to install all other requirements files.
* requirements-base.txt: dependencies that apply broadly to the repository.
* requirements-datasets.txt: dependencies used by datasets in order to acquire or post-process data.
* requirements-distiller.txt: dependencies related to the distiller.

The existence of the `requirements.txt` file is preserved in order to not break existing functionality.